### PR TITLE
FLEX-34712 bug fix for callout positioning on android device rotation

### DIFF
--- a/frameworks/projects/spark/src/spark/components/Callout.as
+++ b/frameworks/projects/spark/src/spark/components/Callout.as
@@ -1685,24 +1685,27 @@ public class Callout extends SkinnablePopUpContainer
     {
     	//callLater() solves bug FLEX-34712 only affecting device and not found on simulator
     	//where calculatePopUpPosition()'s correct x or y may not be immediately available
-        callLater(
-            function():void
-            {
-                // Remove explicit settings if due to Resize effect
-                softKeyboardEffectResetExplicitSize();
+        callLater(queued_systemManager_resizeHandler, [event]);
+    }
+    
+    /**
+     *  @private
+     */
+    private function queued_systemManager_resizeHandler(event:Event):void
+    {
+        // Remove explicit settings if due to Resize effect
+        softKeyboardEffectResetExplicitSize();
         
-                // Screen resize might require a new arrow direction and callout position
-                invalidatePosition();
+        // Screen resize might require a new arrow direction and callout position
+        invalidatePosition();
         
-                if (!isSoftKeyboardEffectActive)
-                {
-                    // Force validation and use new screen size only if the keyboard
-                    // effect is not active. The stage dimensions may be invalid while 
-                    // the soft keyboard is active. See SDK-31860.
-                    validateNow();
-                }
-            }
-        );
+        if (!isSoftKeyboardEffectActive)
+        {
+            // Force validation and use new screen size only if the keyboard
+            // effect is not active. The stage dimensions may be invalid while 
+            // the soft keyboard is active. See SDK-31860.
+            validateNow();
+        }
     }
 }
 }

--- a/frameworks/projects/spark/src/spark/components/Callout.as
+++ b/frameworks/projects/spark/src/spark/components/Callout.as
@@ -1683,7 +1683,7 @@ public class Callout extends SkinnablePopUpContainer
      */
     private function systemManager_resizeHandler(event:Event):void
     {
-    	//callLater() solves bug FLEX-34712 only affecting device and not found on simulator
+    	//callLater() solves bug FLEX-34712 only affecting android device and not affecting ios device or simulator
     	//where calculatePopUpPosition()'s correct x or y may not be immediately available
         callLater(queued_systemManager_resizeHandler, [event]);
     }

--- a/frameworks/projects/spark/src/spark/components/Callout.as
+++ b/frameworks/projects/spark/src/spark/components/Callout.as
@@ -1683,19 +1683,26 @@ public class Callout extends SkinnablePopUpContainer
      */
     private function systemManager_resizeHandler(event:Event):void
     {
-        // Remove explicit settings if due to Resize effect
-        softKeyboardEffectResetExplicitSize();
+    	//callLater() solves bug FLEX-34712 only affecting device and not found on simulator
+    	//where calculatePopUpPosition()'s correct x or y may not be immediately available
+        callLater(
+            function():void
+            {
+                // Remove explicit settings if due to Resize effect
+                softKeyboardEffectResetExplicitSize();
         
-        // Screen resize might require a new arrow direction and callout position
-        invalidatePosition();
+                // Screen resize might require a new arrow direction and callout position
+                invalidatePosition();
         
-        if (!isSoftKeyboardEffectActive)
-        {
-            // Force validation and use new screen size only if the keyboard
-            // effect is not active. The stage dimensions may be invalid while 
-            // the soft keyboard is active. See SDK-31860.
-            validateNow();
-        }
+                if (!isSoftKeyboardEffectActive)
+                {
+                    // Force validation and use new screen size only if the keyboard
+                    // effect is not active. The stage dimensions may be invalid while 
+                    // the soft keyboard is active. See SDK-31860.
+                    validateNow();
+                }
+            }
+        );
     }
 }
 }

--- a/frameworks/projects/spark/src/spark/components/Callout.as
+++ b/frameworks/projects/spark/src/spark/components/Callout.as
@@ -244,8 +244,6 @@ public class Callout extends SkinnablePopUpContainer
     //--------------------------------------------------------------------------
     
     private var invalidatePositionFlag:Boolean = false;
-    
-    private var stageOrientationChangedFlag:Boolean = false;
 
     //--------------------------------------------------------------------------
     //
@@ -766,7 +764,6 @@ public class Callout extends SkinnablePopUpContainer
         // reset state
         invalidatePositionFlag = false;
         arrowDirectionAdjusted = false;
-        stageOrientationChangedFlag = false;
 
         // Add to PopUpManager, calls updatePopUpPosition(), and change state
         super.open(owner, modal);
@@ -776,10 +773,6 @@ public class Callout extends SkinnablePopUpContainer
         
         if (systemManagerParent)
             systemManagerParent.addEventListener(Event.RESIZE, systemManager_resizeHandler);
-            
-        // Detect stage orientation change and set flag
-        if (stage)
-	    stage.addEventListener(StageOrientationEvent.ORIENTATION_CHANGE, stage_orientationChangeHandler);
     }
     
     /**
@@ -794,9 +787,6 @@ public class Callout extends SkinnablePopUpContainer
         
         if (systemManagerParent)
             systemManagerParent.removeEventListener(Event.RESIZE, systemManager_resizeHandler);
-            
-        if (stage)
-            stage.removeEventListener(StageOrientationEvent.ORIENTATION_CHANGE, stage_orientationChangeHandler);
         
         super.close(commit, data);
     }
@@ -812,17 +802,8 @@ public class Callout extends SkinnablePopUpContainer
         // explicit changes to horizontalPostion and verticalPosition.
         if (isOpen && invalidatePositionFlag)
         {
-            //check if stage orientation changed
-            if (stageOrientationChangedFlag)
-            {
-                //queue call to updatePopUpPosition
-                callLater(updatePopUpPosition);
-                stageOrientationChangedFlag = false;
-            }
-            else
-            {
-                updatePopUpPosition();
-            }
+            updatePopUpPosition();
+            invalidatePositionFlag = false;
         }
 
         // Position the arrow
@@ -1702,29 +1683,19 @@ public class Callout extends SkinnablePopUpContainer
      */
     private function systemManager_resizeHandler(event:Event):void
     {
-       	// Remove explicit settings if due to Resize effect
-       	softKeyboardEffectResetExplicitSize();
+        // Remove explicit settings if due to Resize effect
+        softKeyboardEffectResetExplicitSize();
         
         // Screen resize might require a new arrow direction and callout position
         invalidatePosition();
         
-      	if (!isSoftKeyboardEffectActive)
+        if (!isSoftKeyboardEffectActive)
         {
             // Force validation and use new screen size only if the keyboard
             // effect is not active. The stage dimensions may be invalid while 
             // the soft keyboard is active. See SDK-31860.
             validateNow();
         }
-     }
-    
-    /**
-    *  @private
-    */
-    private function stage_orientationChangeHandler(event:StageOrientationEvent):void
-    {
-        //set flag to use in updateDisplayList
-        //for queuing call to updatePopUpPosition
-        stageOrientationChangedFlag = true;
     }
-  }
+}
 }


### PR DESCRIPTION
Created function queued_systemManager_resizeHandler() and moved code from systemManager_resizeHandler() to that new function. New function is called via callLater() from original systemManager_resizeHandler(), allowing for calculatePopUpPosition() to get correct x and y.