### PR TITLE
deleted "removed = source.splice(index, 1)[0];"

### DIFF
--- a/frameworks/projects/apache/src/org/apache/flex/collections/ArrayList.as
+++ b/frameworks/projects/apache/src/org/apache/flex/collections/ArrayList.as
@@ -529,7 +529,6 @@ public class ArrayList extends EventDispatcher
             throw new RangeError(message);
         }
 
-        removed = source.splice(index, 1)[0];
         stopTrackUpdates(removed);
         internalDispatchEvent(CollectionEventKind.REMOVE, removed, index);
         return removed;


### PR DESCRIPTION
removed duplicate manipulation of source array which was causing a second item to be unnecessarily removed in function removeItemAt()