### PR TITLE
Update CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,10 +3,13 @@ support to the Apache Flex SDK.
 
 Apache Flex SDK 4.15.0
 ----------------------
-Ad Pijnenburg, Aleksey, Alex Harui, Andrey Gorbatov, Andy Dufilie, Andrei Tchijov,
-Chris Martin, Christofer Dutz, Dany Dhondt, Darrell Loverin, Erik de Bruin,
-Frédéric Thomas, Harbs,  Josh Tynjala, Justin Mclean, Mark Kessler, Mihai Chira,
-OmPrakash Muppirala, Piotr Zarzycki, Robbyn Gerhardt, Tom Chiverton, Tom Goemaes
+Ad Pijnenburg, Aleksey, Alessandro Palombaro, Alex Harui, Alexander Doroshko, 
+Andrey Gorbatov, Andy Dufilie, Andrei Tchijov, Benjamin Chalupka, Carlos Monteiro, 
+Chris Martin, Christofer Dutz, Curtis Aube, Dany Dhondt, Darrell Loverin, Devin, 
+Erik de Bruin, Frédéric Thomas, goratz, Harbs, Josh Tynjala, Justin Mclean, 
+Konstantin Elstner, Mark Kessler, Mihai Chira, Olaf Krüger, OmPrakash Muppirala,
+Paul Hastings, Piotr Zarzycki, Robbyn Gerhardt, Steve Wright, Tamás Nepusz,
+Tom Chiverton, Tom Goemaes
 
 Apache Flex SDK 4.14.1
 ----------------------


### PR DESCRIPTION
Perhaps this is helpful... if not throw it way ;-)

I've searched for all resolved/closed Jira tickets where "Fix Version = 4.15.0". Then I extract all volunteers that are currently not listed and add it to the "Apache Flex SDK 4.15.0." section.

List of currently not listed volunteers with issue id, ordered by issue id (descend):

[x], Olaf Krüger, FLEX-35003 
[x], Konstantin Elstner, FLEX-34954 
[x], Benjamin Chalupka, FLEX-34891 
[-], goratz, FLEX-34769  
[x], Aleksey, FLEX-34753
[x], Alexander Doroshko, FLEX-34751
[x], Alessandro Palombaro, FLEX-34744 
[x], Devin, FLEX-34741 
[-], Tamás Nepusz, FLEX-34727
[-], Carlos Monteiro, FLEX-34581
[x], Steve Wright, FLEX-34028
[-], Paul Hastings, FLEX-33908
[x], Curtis Aube, FLEX-33537

[x]: Listed in RELEASE_NOTES
[-]: NOT listed in RELEASE_NOTES