### PR TITLE
Fix issue with Spark Grid scrolling/alignment when using locked columns/rows

### DIFF
--- a/frameworks/projects/spark/src/spark/components/Grid.as
+++ b/frameworks/projects/spark/src/spark/components/Grid.as
@@ -4396,6 +4396,7 @@ public class Grid extends Group implements IDataGridElement, IDataProviderEnhanc
 			{
                 gridLayout.topGridView = topGridView = createGridView();
 				topGridView.gridViewLayout.verticalScrollingLocked = true;
+				topGridView.gridViewLayout.horizontalScrollPosition = centerGridView.horizontalScrollPosition;
 				gridViewsChanged = true;
 			}
             
@@ -4432,6 +4433,7 @@ public class Grid extends Group implements IDataGridElement, IDataProviderEnhanc
 			{
                 gridLayout.leftGridView = leftGridView = createGridView();
 				leftGridView.gridViewLayout.horizontalScrollingLocked = true;
+				leftGridView.gridViewLayout.verticalScrollPosition = centerGridView.verticalScrollPosition;
 				gridViewsChanged = true;
 			}
             

--- a/frameworks/projects/spark/src/spark/components/gridClasses/GridViewLayout.as
+++ b/frameworks/projects/spark/src/spark/components/gridClasses/GridViewLayout.as
@@ -866,7 +866,7 @@ public class GridViewLayout extends LayoutBase
      */
     override public function measure():void
     {
-        const gridView:GridView = target as GridView;  // TBD: requestedRowCount should be a local property...
+        const gridView:GridView = target as GridView;
         const grid:Grid = this.grid;
         
         if (!gridView || !grid)
@@ -1876,10 +1876,12 @@ public class GridViewLayout extends LayoutBase
         const gridColumn:GridColumn = getGridColumn(columnIndex);
         if (gridColumn)
         {
-            renderer.rowIndex = rowIndex;
+            renderer.rowIndex = rowIndex + viewRowIndex;
             renderer.column = gridColumn;
             if (dataItem == null)
                 dataItem = getDataProviderItem(rowIndex);
+			rowIndex += viewRowIndex;
+			columnIndex += viewColumnIndex;
             
             renderer.label = gridColumn.itemToLabel(dataItem);
             


### PR DESCRIPTION
Contrary to StackOverflow belief, lockedColumnCount and lockedRowCount are usable in the Spark DataGrid, but the item renderer "selected" state is misaligned. Scrollbars are also misaligned when changing dataProvider. This fixes it.